### PR TITLE
remove Rails Bricks as it is no longer exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ You can edit this list from [here](https://github.com/ekremkaraca/awesome-rails/
 
 |Generator|Ready to run|Complex Apps|Sets git|Heroku|
 | ------ | ------ | ------ | ------ | ------ |
-|[Rails Bricks](http://www.railsbricks.net/)|yes|Only starting point.|no|yes|
 |[Rails Composer](https://github.com/RailsApps/rails-composer)|yes, but Stripe needs to be configured|Example apps reaching a SaaS with Stripe.|yes|yes|
 |[Prelang](http://prelang.com/)|Had to modify database credentials manually|Customizable models. But no payments.|yes|no|
 |[Hobo](http://www.hobocentral.net/)|Rails version problems, if using a late version|It seems according screencast, helps a lot with MVC boilerplate.|no|no|


### PR DESCRIPTION
Remove `Rails Bricks` as it is no longer exists.
www.railsbricks.net