### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ A collection of all things awesome about Rails. Inspired by other awesome-* stuf
 
 #### Blogging
 
-- [publify](https://github.com/publify/publify) - A self hosted Web publishing platform on Rails  [Live](http://demo.publify.co)
+- [publify](https://github.com/publify/publify) - A self hosted Web publishing platform on Rails  [Live](https://demo.publify.co/)
 - [obtvse2](https://github.com/natew/obtvse2) - A clean and simple markdown blogging platform on Rails
 
 #### Community Management
 
-- [discourse](https://github.com/discourse/discourse) -A platform for community discussion  [Live](http://try.discourse.org)
+- [discourse](https://github.com/discourse/discourse) -A platform for community discussion  [Live](https://try.discourse.org/)
 - [loomio](https://github.com/loomio/loomio) -  A collaborative decision-making tool that makes it easy for anyone [Live](https://www.loomio.org)
 - [campo](https://github.com/chloerei/campo) - A lightweight forum application, base on Ruby on Rails  [Live](http://codecampo.com)
 - [onebody](https://github.com/churchio/onebody) - A private member portal for churches built with Ruby on Rails [Live](https://church.io)
@@ -74,30 +74,30 @@ A collection of all things awesome about Rails. Inspired by other awesome-* stuf
 #### Crowdfunding & Fundraising
 
 - [selfstarter](https://github.com/lockitron/selfstarter) - Roll your own crowdfunding  [Live](http://www.selfstarter.us)
-- [catarse](https://github.com/catarse/catarse) - The first open source crowdfunding platform for creative projects in the world  [Live](http://catarse.me)
-- [CrowdtiltOpen](https://github.com/Crowdtilt/CrowdtiltOpen) - Open source crowdfunding platform  [Live](http://open.crowdtilt.com)
+- [catarse](https://github.com/catarse/catarse) - The first open source crowdfunding platform for creative projects in the world  [Live](https://catarse.me/)
+- [CrowdtiltOpen](https://github.com/Crowdtilt/CrowdtiltOpen) - Open source crowdfunding platform  [Live](https://www.tilt.com/index.html)
 
 #### Developer Tools
 
 - [gitlabhq](https://github.com/gitlabhq/gitlabhq) -  Open source software to collaborate on code  [Live](https://gitlab.com/gitlab-org/gitlab-ce) -
 - [rubygems.org](https://github.com/rubygems/rubygems.org) -  The Ruby community's gem hosting service  [Live](https://rubygems.org)
-- [codetriage.com](https://github.com/codetriage/codetriage) -  Help out your favorite open source projects and become a better developer while doing it.  [Live](http://www.codetriage.com)
+- [codetriage.com](https://github.com/codetriage/codetriage) -  Help out your favorite open source projects and become a better developer while doing it.  [Live](https://www.codetriage.com/)
 - [intercityup.com](https://github.com/intercity/intercity-next) -  Control Panel for hosting Ruby on Rails
 
 #### E-commerce
 
-- [Spree](https://github.com/spree/spree) -  Spree is a complete open source e-commerce solution for Ruby on Rails.  [Live](http://spreecommerce.com)
+- [Spree](https://github.com/spree/spree) -  Spree is a complete open source e-commerce solution for Ruby on Rails.  [Live](https://spreecommerce.com/)
 
 #### Health
 
 - [quant](https://github.com/jdjkelly/quant) -  Quant is a prototype/experiment of a personal health tracker
-- [dgi-db](https://github.com/genome/dgi-db) -  Rails frontend to The Genome Institute's drug gene interaction database
+- [dgi-db](https://github.com/griffithlab/dgi-db) -  Rails frontend to The Genome Institute's drug gene interaction database
 - [popHealth](https://github.com/pophealth/popHealth) -  An Open Source Population Health Reporting Prototype  
 
 #### Learning
 
 - [canvas-lms](https://github.com/instructure/canvas-lms) -  A new, open-source learning management system by Instructure Inc  
-- [theodinproject](https://github.com/TheOdinProject/theodinproject) -  A project that aims to teach web development for free  [Live](http://www.theodinproject.com)
+- [theodinproject](https://github.com/TheOdinProject/theodinproject) -  A project that aims to teach web development for free  [Live](https://www.theodinproject.com/)
 - [cyberdojo](https://github.com/JonJagger/cyber-dojo) -  Free in-browser coding-dojo [Live](http://cyber-dojo.org)
 - [mumuki-laboratory](https://github.com/mumuki/mumuki-laboratory) - Where students practice and receive automated and human feedback [Live](http://mumuki.io)
 
@@ -109,7 +109,7 @@ A collection of all things awesome about Rails. Inspired by other awesome-* stuf
 
 #### Nature
 
-- [growstuff](https://github.com/Growstuff/growstuff) -  An open source/open data project to create a website for food gardeners  [Live](http://growstuff.org)
+- [growstuff](https://github.com/Growstuff/growstuff) -  An open source/open data project to create a website for food gardeners  [Live](http://www.growstuff.org/)
 - [inaturalist](https://github.com/inaturalist/inaturalist) -  Open source Rails app behind iNaturalist.org [Live](http://www.inaturalist.org)
 - [OpenFarm](https://github.com/openfarmcc/OpenFarm) -  A free and open database for farming and gardening knowledge  
 
@@ -130,7 +130,7 @@ A collection of all things awesome about Rails. Inspired by other awesome-* stuf
 - [kanban](https://github.com/somlor/kanban) - A Trello clone in Rails and Backbone.js  [Live](http://kanban.seanomlor.com)
 - [openproject](https://github.com/opf/openproject) - A web based project management system built on Ruby on Rails  [Live](https://www.openproject.org)
 - [people](https://github.com/netguru/people) - Manage people within the projects
-- [WebsiteOne](https://github.com/AgileVentures/WebsiteOne) - A platform for online collaboration and crowdsourced project development [Live](http://www.agileventures.org)
+- [WebsiteOne](https://github.com/AgileVentures/WebsiteOne) - A platform for online collaboration and crowdsourced project development [Live](https://www.agileventures.org/)
 - [houston](https://github.com/houston/houston-core) - Mission control for your projects and teammates  
 - [hours](https://github.com/defactosoftware/hours) - A complete time registration app for teams [Live](https://happyhours.io)
 
@@ -140,7 +140,7 @@ A collection of all things awesome about Rails. Inspired by other awesome-* stuf
 - [coderwall](https://github.com/assemblymade/coderwall) - Professional network for software engineers  [Live](https://coderwall.com)
 - [follow-all](https://github.com/codeforamerica/follow-all) - Follow all the members of a Twitter list with a single click
 - [Hashrobot](https://github.com/rysmith/hashrobot) - A social media assistant  [Live](http://www.hashrobot.com)
-- [socify](https://github.com/sudharti/socify) - an open source social networking platform written in Ruby on Rails
+- [socify](https://github.com/scaffeinate/socify) - an open source social networking platform written in Ruby on Rails
 - [RoRdit](https://github.com/mertbulan/RoRdit) - Link aggregation web app similar with Reddit in Ruby on Rails [Live](https://rordit.herokuapp.com)
 - [Mastodon](https://github.com/tootsuite/mastodon) - GNU Social-compatible microblogging server [Live](https://mastodon.social)
 
@@ -167,13 +167,13 @@ A collection of all things awesome about Rails. Inspired by other awesome-* stuf
 - [RapidFTR](https://github.com/rapidftr/RapidFTR) -  An Android-based mobile application that lets aid workers collect, sort and share information about children in emergency situations
 - [danbooru](https://github.com/r888888888/danbooru) - A taggable image board written in Rails 3 [Live](http://testbooru.donmai.us)
 - [sharetribe](https://github.com/sharetribe/sharetribe) - A platform for setting up your own peer-to-peer marketplace online [Live](https://www.sharetribe.com)
-- [AsakusaSatellite](https://github.com/codefirst/AsakusaSatellite) - A realtime chat application for developers [Live](http://www.codefirst.org/AsakusaSatellite)
+- [AsakusaSatellite](https://github.com/codefirst/AsakusaSatellite) - A realtime chat application for developers [Live](https://www.codefirst.org/AsakusaSatellite)
 - [sanataro](https://github.com/kaznum/sanataro) - Simple Web Household Account Book. built with Ruby on Rails [Live](http://sanataro.herokuapp.com)
 - [opencongress](https://github.com/sunlightlabs/opencongress) - An open website for opening Congress
 - [rletters](https://github.com/rletters/rletters) - Web application designed to perform digital humanities research tasks on a database of journal articles [Live](http://www.rletters.net)
 - [scholarsphere](https://github.com/psu-stewardship/scholarsphere) - A web application for ingest, curation, search, and display of digital assets  
 - [opensit](https://github.com/danbartlett/opensit) - An open source meditation community [Live](http://opensit.com)
-- [fromthepage](https://github.com/benwbrum/fromthepage) - A wiki-like application for crowdsourcing transcription of handwritten documents  [Live](http://beta.fromthepage.com)
+- [fromthepage](https://github.com/benwbrum/fromthepage) - A wiki-like application for crowdsourcing transcription of handwritten documents  [Live](https://www.fromthepage.com/)
 - [graff_mags](https://github.com/dankleiman/graff_mags) - Upload and display collection of 2000+ graffiti magazines  [Live](http://graffmags.herokuapp.com)
 - [trado](https://github.com/Jellyfishboy/trado) - lightweight, easy to use e-commerce platform designed for sole traders and SME businesses  
 - [CoRM](https://github.com/SIGIRE/CoRM) - Easier than a CRM [Live](http://www.corm.fr)
@@ -191,7 +191,7 @@ A collection of all things awesome about Rails. Inspired by other awesome-* stuf
 - [rentmybikes-rails](https://github.com/balanced/rentmybikes-rails) - A fully functional, deployable marketplace implementation using Balanced API for Rails
 - [lavish](https://github.com/mquan/lavish) - a rails app that generates Bootstrap color scheme from an image  [Live](http://www.lavishbootstrap.com)
 - [coursemology2](https://github.com/Coursemology/coursemology2) - Rails 4 re-write of Coursemology  
-- [Helpy](https://github.com/scott/helpy) - Rails 4 Helpdesk. Includes Multilingual Knowledgebase, Email Tickets, Community [Live](http://helpy.io)
+- [Helpy](https://github.com/scott/helpy) - Rails 4 Helpdesk. Includes Multilingual Knowledgebase, Email Tickets, Community [Live](https://helpy.io/)
 - [expertiza](https://github.com/expertiza/expertiza) - web application where students can submit and peer-review learning objects (articles, code, web sites, etc).
 - [covoiturage-libre](https://github.com/covoiturage-libre/covoiturage-libre) - a Carpooling Open Source platform in Rails 5
 - [hitobito](https://github.com/hitobito/hitobito) - A web application to manage complex group hierarchies with members, events and a lot more - [Live](http://hitobito.com/en)


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/genome/dgi-db | https://github.com/griffithlab/dgi-db 
https://github.com/sudharti/socify | https://github.com/scaffeinate/socify 


### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://www.codefirst.org/AsakusaSatellite | https://www.codefirst.org/AsakusaSatellite 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://beta.fromthepage.com | https://www.fromthepage.com/ 
http://catarse.me | https://catarse.me/ 
http://demo.publify.co | https://demo.publify.co/ 
http://growstuff.org | http://www.growstuff.org/ 
http://helpy.io | https://helpy.io/ 
http://open.crowdtilt.com | https://www.tilt.com/index.html 
http://spreecommerce.com | https://spreecommerce.com/ 
http://try.discourse.org | https://try.discourse.org/ 
http://www.agileventures.org | https://www.agileventures.org/ 
http://www.codetriage.com | https://www.codetriage.com/ 
http://www.theodinproject.com | https://www.theodinproject.com/ 
