### PR TITLE
Add nativeapptemplateapi to Starters/Boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,7 @@
 - [jumpstart(excid3)](https://github.com/excid3/jumpstart) - Easily jumpstart a new Rails application with a bunch of great features by default.
 - [jumpstart(thomasvanholder)](https://github.com/thomasvanholder/jumpstart) - Template for set-up of Rails 6, Tailwind 2.0 and Devise.
 - [kickoff_tailwind](https://github.com/justalever/kickoff_tailwind) - A rapid Rails 6 application template for personal use bundled with Tailwind CSS.
+- [nativeapptemplateapi](https://github.com/nativeapptemplate/nativeapptemplateapi) - A Rails 8.1 multi-tenant API backend for native iOS (Swift/SwiftUI) and Android (Kotlin/Compose) apps. Uses acts_as_tenant, devise_token_auth, Pundit, Solid Queue/Cache/Cable, and PostgreSQL (using Rails 8.1).
 - [Rails Blocks](https://railsblocks.com/) - A collection of Ruby on Rails UI components using Tailwind CSS and Stimulus controllers.
 - [rails-devise-graphql](https://github.com/zauberware/rails-devise-graphql) - A Rails 6 boilerplate to create your next Saas product. Preloaded with graphQL, devise, JWT, CanCanCan, RailsAdmin, Rubocop, Rspec, and more.
 - [rails-template(mattbrictson)](https://github.com/mattbrictson/rails-template) - Application template for Rails 6 projects; preloaded with best practices for TDD, security, deployment, and developer productivity.


### PR DESCRIPTION
## Summary

Adds [nativeapptemplateapi](https://github.com/nativeapptemplate/nativeapptemplateapi) to the Starters/Boilerplates section.

A Rails 8.1 multi-tenant API backend for native iOS (Swift/SwiftUI) and Android (Kotlin/Compose) apps. Open source under MIT license.

Stack: Rails 8.1, PostgreSQL, acts_as_tenant, devise_token_auth, Pundit, Solid Queue/Cache/Cable, 205 Minitest tests.

Placed alphabetically between `kickoff_tailwind` and `Rails Blocks`.