### PR TITLE
Add Tidewave Rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@
 - [sprockets](https://github.com/rails/sprockets) - A gem to compile & serve web assets. [:red_circle:](https://rubygems.org/gems/sprockets)
 - [stimulus-rails](https://github.com/hotwired/stimulus-rails) - A gem to integrate Stimulus.js in Rails apps. [:red_circle:](https://rubygems.org/gems/stimulus-rails)
 - [subflag-rails](https://github.com/subflag/sdk/tree/main/packages/subflag-rails) - A gem for feature flags and dynamic config that uses ActiveRecord. [🔴](https://rubygems.org/gems/subflag-rails)
+- [tidewave](https://github.com/tidewave-ai/tidewave_rails) - MCP server for agentic Rails development, runtime-level tools for your agent to talk to your running app. [:red_circle:](https://rubygems.org/gems/tidewave)
 - [tinymce-rails](https://github.com/spohlenz/tinymce-rails) - A gem to integrate Tinymce in Rails apps. [:red_circle:](https://rubygems.org/gems/tinymce-rails)
 - [transloadit-rails](https://github.com/transloadit/rails-sdk) - A gem to integrate Transloadit's file uploading and encoding service. [:red_circle:](https://rubygems.org/gems/transloadit-rails)
 - [trove](https://github.com/ankane/trove) - A gem to handle machine learning models deployment. [:red_circle:](https://rubygems.org/gems/trove)


### PR DESCRIPTION
Tidewave Rails is an MCP server for Rails development. It provides runtime-level tools for developing Ruby on Rails apps using coding agents.

Your agent will be able to talk to your running application: execute code in the running app (like a rails console for agents), read the app's logs, query your development database, resolve source locations of classes and methods, and read documentation pinned to the exact gem versions in your app's Gemfile.